### PR TITLE
Add platform activation infrastructure

### DIFF
--- a/.bitbucket/pull_request_template.md
+++ b/.bitbucket/pull_request_template.md
@@ -1,0 +1,33 @@
+# Pull Request
+
+## Summary
+
+-
+
+## Type
+
+- [ ] Documentation
+- [ ] Course or research content
+- [ ] Community or event operations
+- [ ] Bitbucket infrastructure
+- [ ] Website or publishing pipeline
+
+## Source discipline
+
+- [ ] Public claims are backed by links or existing repository sources.
+- [ ] Draft, strategy, and target language is clearly labeled.
+- [ ] No credentials, private emails, internal contracts, or CRM data are included.
+
+## Outreach and publication
+
+- [ ] This change does not send invitations, publish posts, or claim partnerships.
+- [ ] Any external message is included as a draft for maintainer approval.
+
+## Platform sync
+
+- [ ] GitHub/GitLab/Bitbucket docs or issue queues are updated when relevant.
+- [ ] Branch restrictions and protected-branch assumptions still hold.
+
+## Review notes
+
+-

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,19 @@ TELEGRAM_BOT_TOKEN=
 DISCORD_WEBHOOK_URL=
 WEBSITE_DEPLOY_TOKEN=
 
+# GitLab activation. Keep real values only in local .env or a secret manager.
+GITLAB_HOST=https://gitlab.com
+GITLAB_TOKEN=
+GITLAB_NAMESPACE=
+GITLAB_PROJECT_PATH=ABC4RD
+GITLAB_PROJECT_NAME=ABC4RD
+
+# Bitbucket activation. Keep real values only in local .env or a secret manager.
+# Use BITBUCKET_AUTH_MODE=Bearer for Bitbucket access tokens.
+# Use BITBUCKET_AUTH_MODE=Basic with BITBUCKET_USERNAME for Atlassian API tokens.
+BITBUCKET_AUTH_MODE=Bearer
+BITBUCKET_TOKEN=
+BITBUCKET_USERNAME=
+BITBUCKET_WORKSPACE=
+BITBUCKET_PROJECT_KEY=
+BITBUCKET_MAIN_REPO=ABC4RD

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# Pull Request
+
+## Summary
+
+-
+
+## Type
+
+- [ ] Documentation
+- [ ] Course or research content
+- [ ] Community or event operations
+- [ ] GitHub infrastructure
+- [ ] Website or publishing pipeline
+
+## Source discipline
+
+- [ ] Public claims are backed by links or existing repository sources.
+- [ ] Draft, strategy, and target language is clearly labeled.
+- [ ] No credentials, private emails, internal contracts, or CRM data are included.
+
+## Review notes
+
+-

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,43 @@
+labels:
+  - name: area:ai-education
+    color: "1d76db"
+    description: AI course, labs, literacy, and learning pathway work.
+  - name: area:bitcoin-education
+    color: "f9d0c4"
+    description: Bitcoin, Lightning, Nostr, custody, mining, and treasury education.
+  - name: area:community
+    color: "0e8a16"
+    description: Community operations, governance, onboarding, and public support.
+  - name: area:events
+    color: "fbca04"
+    description: Conferences, workshops, meetups, and event activation.
+  - name: area:partners
+    color: "5319e7"
+    description: Partner mapping, outreach drafts, and collaboration opportunities.
+  - name: area:research
+    color: "0052cc"
+    description: Evidence, citation review, source maps, and media-kit materials.
+  - name: area:site
+    color: "c2e0c6"
+    description: Website, docs navigation, OpenGraph, and publishing integration.
+  - name: good first issue
+    color: "7057ff"
+    description: Small, clear task suitable for a first public contribution.
+  - name: help wanted
+    color: "008672"
+    description: Task where public contributor support is welcome.
+  - name: needs:approval
+    color: "b60205"
+    description: Requires human approval before external publication or outreach.
+  - name: needs:evidence
+    color: "d93f0b"
+    description: Needs public source review before claims can be treated as factual.
+  - name: priority:high
+    color: "b60205"
+    description: Important near-term work for public credibility or operations.
+  - name: status:draft
+    color: "ededed"
+    description: Draft work that is not ready for public publication.
+  - name: status:review
+    color: "fbca04"
+    description: Ready for source, editorial, or maintainer review.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,6 +2,18 @@ labels:
   - name: area:ai-education
     color: "1d76db"
     description: AI course, labs, literacy, and learning pathway work.
+  - name: area:agents
+    color: "5319e7"
+    description: AI agents, tool use, orchestration, and approval-gated workflows.
+  - name: area:agi
+    color: "0052cc"
+    description: AGI literacy, evaluations, preparedness, and governance.
+  - name: area:asi-safety
+    color: "d93f0b"
+    description: ASI safety, alignment, scalable oversight, and red-team work.
+  - name: area:blockchain-trust
+    color: "f9d0c4"
+    description: Credentials, provenance, attestations, incentives, and Bitcoin workflows.
   - name: area:bitcoin-education
     color: "f9d0c4"
     description: Bitcoin, Lightning, Nostr, custody, mining, and treasury education.

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Link check
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --no-progress --accept 200,206,429 "**/*.md"
+          args: --no-progress --accept 200,206,403,429 "**/*.md"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,11 @@
+stages:
+  - validate
+
+markdown:
+  stage: validate
+  image: node:lts
+  script:
+    - npx --yes markdownlint-cli README.md "*.md" "docs/*.md" ".gitlab/**/*.md" ".github/**/*.md"
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/.gitlab/issue_templates/course-module.md
+++ b/.gitlab/issue_templates/course-module.md
@@ -1,0 +1,24 @@
+# Course Module
+
+## Goal
+
+Describe the learner outcome for this module.
+
+## Repository connection
+
+- Course:
+- Module or lesson:
+- Related source:
+
+## Useful output
+
+- [ ] Outline
+- [ ] Lab
+- [ ] Reading list
+- [ ] Good first issue
+- [ ] Review checklist
+
+## Approval
+
+- [ ] Public claims are source-backed.
+- [ ] No private credentials or internal notes are included.

--- a/.gitlab/issue_templates/event-activation.md
+++ b/.gitlab/issue_templates/event-activation.md
@@ -1,0 +1,26 @@
+# Event Activation
+
+## Event
+
+- Name:
+- Official URL:
+- Dates:
+- Location:
+
+## ABC4RD angle
+
+Explain the education, research, course, or community reason to track this event.
+
+## Useful output
+
+- [ ] Watch note
+- [ ] Workshop draft
+- [ ] Partner message draft
+- [ ] Course issue
+- [ ] Recap draft
+
+## Approval gate
+
+- [ ] Sources checked.
+- [ ] No partnership or sponsorship claim.
+- [ ] Human approval required before outreach or publication.

--- a/.gitlab/issue_templates/partner-draft.md
+++ b/.gitlab/issue_templates/partner-draft.md
@@ -1,0 +1,22 @@
+# Partner Draft
+
+## Target
+
+- Person, group, company, or event:
+- Public URL:
+- Why this target matters:
+
+## Proposed message
+
+Draft only. Do not send before maintainer approval.
+
+```text
+
+```
+
+## Risk check
+
+- [ ] Message does not imply confirmed partnership.
+- [ ] Message points to a concrete learning artifact.
+- [ ] Follow-up owner is known.
+- [ ] Human approval is recorded before sending.

--- a/.gitlab/issue_templates/source-evidence.md
+++ b/.gitlab/issue_templates/source-evidence.md
@@ -1,0 +1,18 @@
+# Source Evidence
+
+## Claim or topic
+
+What should this source support?
+
+## Public source
+
+- URL:
+- Publisher:
+- Date:
+
+## Review
+
+- [ ] Source is public.
+- [ ] Wording is narrow and accurate.
+- [ ] Private material is not included.
+- [ ] Reusable citation text is proposed.

--- a/.gitlab/merge_request_templates/default.md
+++ b/.gitlab/merge_request_templates/default.md
@@ -1,0 +1,28 @@
+# Merge Request
+
+## Summary
+
+-
+
+## Type
+
+- [ ] Documentation
+- [ ] Course or research content
+- [ ] Community or event operations
+- [ ] GitLab infrastructure
+- [ ] Website or publishing pipeline
+
+## Source discipline
+
+- [ ] Public claims are backed by links or existing repository sources.
+- [ ] Draft, strategy, and target language is clearly labeled.
+- [ ] No credentials, private emails, internal contracts, or CRM data are included.
+
+## Outreach and publication
+
+- [ ] This change does not send invitations, publish posts, or claim partnerships.
+- [ ] Any external message is included as a draft for maintainer approval.
+
+## Review notes
+
+-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,4 +15,3 @@ ABC4RD Academy welcomes contributors from different countries, languages, discip
 - Publishing private contact details or credentials.
 - Spam or misleading partner claims.
 - Unsupported claims presented as fact.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,4 +25,3 @@ Thanks for helping build ABC4RD Academy in public.
 - Claims are backed by public sources.
 - The tone is useful, not hype-driven.
 - No credentials, private emails, or internal-only details are included.
-

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ See [docs/github-roadmap.md](docs/github-roadmap.md).
 
 - [ABC4RD operating loop](docs/operating-loop.md)
 - [Event activation pipeline](docs/event-activation-pipeline.md)
+- [Frontier innovation strategy](docs/frontier-innovation-strategy.md)
 - [GitHub issue backlog](docs/github-issue-backlog.md)
 - [GitLab activation](docs/gitlab-activation.md)
 - [GitLab starter issues](docs/gitlab-starter-issues.md)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This is the main public hub for ABC4RD Academy:
 - organization roadmap;
 - website and docs direction;
 - publishing and safety policy;
+- weekly operating loop and event activation pipeline;
+- GitHub, GitLab, and Bitbucket publishing coordination;
 - issue templates for public collaboration;
 - source-backed partner and ecosystem briefs;
 - coordination links to course, research, and community repositories.
@@ -73,6 +75,18 @@ Use Discussions for broader conversation:
 
 See [docs/github-roadmap.md](docs/github-roadmap.md).
 
+## Operating loop
+
+- [ABC4RD operating loop](docs/operating-loop.md)
+- [Event activation pipeline](docs/event-activation-pipeline.md)
+- [GitHub issue backlog](docs/github-issue-backlog.md)
+- [GitLab activation](docs/gitlab-activation.md)
+- [GitLab starter issues](docs/gitlab-starter-issues.md)
+- [Bitbucket activation](docs/bitbucket-activation.md)
+- [Bitbucket starter issues](docs/bitbucket-starter-issues.md)
+- [Partner activity queue](docs/partner-activity-queue.md)
+- [Outreach drafts](docs/outreach-drafts.md)
+
 ## Safety
 
 ABC4RD uses a draft-first publishing model:
@@ -86,10 +100,10 @@ See [docs/publishing-safety.md](docs/publishing-safety.md).
 
 ## Channels
 
-- Website: http://abc4rd.org/
-- GitHub org: https://github.com/ABC4RDacademy
-- X: https://x.com/academy_abc4rd
-- Telegram channel: https://www.t.me/abc4rdchannel
-- Telegram bot: https://www.t.me/abc4rd_bot
-- Telegram chat: https://www.t.me/abc4rdchat
-- Discord: https://discord.com/invite/3AgRv6wKPQ
+- Website: [abc4rd.org](http://abc4rd.org/)
+- GitHub org: [ABC4RDacademy](https://github.com/ABC4RDacademy)
+- X: [@academy_abc4rd](https://x.com/academy_abc4rd)
+- Telegram channel: [abc4rdchannel](https://www.t.me/abc4rdchannel)
+- Telegram bot: [abc4rd_bot](https://www.t.me/abc4rd_bot)
+- Telegram chat: [abc4rdchat](https://www.t.me/abc4rdchat)
+- Discord: [ABC4RD invite](https://discord.com/invite/3AgRv6wKPQ)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,4 +10,3 @@ Please report security issues privately to the project maintainers. Do not open 
 - Rotate credentials if exposure is suspected.
 - Use least-privilege tokens for bots and integrations.
 - Keep generated channel posts in draft mode until human approval.
-

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,14 @@
+image: node:lts
+
+pipelines:
+  default:
+    - step:
+        name: Validate Markdown
+        script:
+          - npx --yes markdownlint-cli README.md "*.md" "docs/*.md" ".github/**/*.md" ".gitlab/**/*.md" ".bitbucket/**/*.md"
+  pull-requests:
+    "**":
+      - step:
+          name: Validate Markdown
+          script:
+            - npx --yes markdownlint-cli README.md "*.md" "docs/*.md" ".github/**/*.md" ".gitlab/**/*.md" ".bitbucket/**/*.md"

--- a/docs/bitbucket-activation.md
+++ b/docs/bitbucket-activation.md
@@ -1,0 +1,122 @@
+# Bitbucket Activation
+
+This playbook describes how ABC4RD can use Bitbucket as a controlled repository
+channel without fragmenting the public project or exposing credentials.
+
+## Operating decision
+
+Keep GitHub as the current public source of truth until maintainers approve a
+formal migration. Use Bitbucket for one of these controlled roles:
+
+- private maintainer backup;
+- partner-facing review copy;
+- repository mirror for teams already using Atlassian tools;
+- issue and sprint workspace for a specific course, event, or partner track;
+- automation testbed for draft-only publishing workflows.
+
+Do not run bidirectional repository synchronization until maintainers have a
+written conflict-resolution plan.
+
+## Immediate setup
+
+1. Rotate any Bitbucket API token that was pasted into chat, email, issues, logs,
+   screenshots, or documents.
+2. Create a fresh token with the minimum required scopes and a short expiration.
+3. Confirm the Bitbucket workspace slug and project key.
+4. Create the `ABC4RD` repository with the same description, license, and README
+   positioning as the GitHub repository.
+5. Add a `bitbucket` remote locally only after the repository URL is confirmed.
+6. Push the protected `main` branch and tags.
+7. Configure branch restrictions, default reviewers, issue status tags, and
+   access groups before inviting contributors.
+
+## Local automation
+
+Use the prepared scripts from the `github_work` directory after a fresh token is
+stored in local environment variables:
+
+```powershell
+$env:BITBUCKET_AUTH_MODE = "Bearer"
+$env:BITBUCKET_TOKEN = "<fresh-token>"
+$env:BITBUCKET_WORKSPACE = "<workspace-slug>"
+$env:BITBUCKET_PROJECT_KEY = "<project-key>"
+
+.\PUBLISH_BITBUCKET.ps1 -ConfigureBranchRestrictions
+.\CREATE_BITBUCKET_STARTER_ISSUES.ps1
+```
+
+Repositories are created as private by default. Add `-Public` only after
+maintainer approval. Add `-Push` when the remote and repository visibility have
+been checked.
+
+## Activity model
+
+Use Bitbucket activity for concrete, reviewable work:
+
+- one project milestone per public sprint;
+- pull requests for documentation, curriculum, research, and website changes;
+- issues for `course`, `research`, `community`, `event`, `partner`, `security`,
+  and `good first issue`;
+- draft-only outreach tasks that require human approval before sending;
+- weekly recap issues that link back to merged work.
+- pull requests created with `.bitbucket/pull_request_template.md`;
+- Markdown validation through `bitbucket-pipelines.yml`.
+
+## Outreach guardrails
+
+Invitations, subscriptions, event submissions, and partner messages should be
+done from an approved account and only after review.
+
+Before any external action, record:
+
+- target person, group, company, community, or event;
+- public reason ABC4RD should engage;
+- proposed message;
+- source-backed learning artifact to share;
+- expected follow-up owner;
+- risk level if the target interprets the message as a partnership claim.
+
+## Token handling
+
+Treat any token pasted into chat as exposed. Revoke it and create a fresh token
+with the minimum required scopes.
+
+Recommended token usage:
+
+- read-only scope for repository audits;
+- repository write scope only for pushes and pull requests;
+- project or workspace admin scope only for setup automation;
+- short expiration dates for all automation tokens;
+- local ignored environment files or secure CI variables only.
+
+## First ten actions
+
+| Order | Action | Output |
+| --- | --- | --- |
+| 1 | Rotate exposed token | Fresh least-privilege credential |
+| 2 | Confirm workspace and project key | Bitbucket remote plan |
+| 3 | Create `ABC4RD` repository | Visible controlled mirror target |
+| 4 | Add protected branch rules | Governance baseline |
+| 5 | Push `main` and tags | Initial repository copy |
+| 6 | Add status tags and starter issues | Public work queue |
+| 7 | Open first pull request | Small documentation improvement |
+| 8 | Draft partner and event queue | Reviewed outreach candidates |
+| 9 | Invite approved maintainers only | Accountable access list |
+| 10 | Publish weekly recap draft | Human-reviewed community update |
+
+## Automation boundary
+
+Automation may create repositories, labels, issues, branches, pull requests, and
+draft messages after credentials and workspace settings are confirmed. It should
+not mass-invite users, subscribe to communities, submit event applications, or
+send partner outreach without a human-approved target list and message.
+
+## Sources
+
+- [Bitbucket Cloud REST API](https://developer.atlassian.com/cloud/bitbucket/rest/intro/)
+- [Bitbucket access tokens](https://support.atlassian.com/bitbucket-cloud/docs/access-tokens/)
+- [Bitbucket repositories API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/)
+- [Bitbucket issue tracker API](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-issue-tracker/)
+- [Bitbucket pull request templates](https://support.atlassian.com/bitbucket-cloud/kb/pull-request-templates-in-bitbucket-cloud/)
+- [Bitbucket Pipelines for Node.js](https://support.atlassian.com/bitbucket-cloud/docs/javascript-nodejs-with-bitbucket-pipelines/)
+- [Bitbucket branch restrictions](https://support.atlassian.com/bitbucket-cloud/docs/use-branch-permissions/)

--- a/docs/bitbucket-starter-issues.md
+++ b/docs/bitbucket-starter-issues.md
@@ -1,0 +1,69 @@
+# Bitbucket Starter Issues
+
+These issues are ready to create in Bitbucket after the workspace, repository,
+and fresh token are configured.
+
+Bitbucket issues do not map one-to-one to GitHub labels, so use status tags in
+the issue body and keep the same naming discipline as `.github/labels.yml`.
+
+## Priority issues
+
+### Platform mirror: verify Bitbucket repository page and README rendering
+
+Status tags: `area:site`, `priority:high`, `status:review`
+
+Output:
+
+- repository description and public/private decision confirmed;
+- README rendering checked;
+- website, GitHub, Telegram, Discord, and X links verified;
+- public wording reviewed for unverified partnership claims;
+- Bitbucket URL recorded in `docs/bitbucket-activation.md`.
+
+### Governance: configure branch restrictions and pull request checks
+
+Status tags: `area:community`, `priority:high`, `needs:approval`
+
+Output:
+
+- force-push protection for `main`;
+- branch deletion protection for `main`;
+- at least one required approval;
+- completed pull request tasks before merge;
+- approval reset when pull requests change.
+
+### Activity queue: open event, partner, course, research, and community drafts
+
+Status tags: `area:events`, `area:partners`, `area:research`, `status:draft`
+
+Output:
+
+- one event watch draft;
+- one partner outreach draft;
+- one course issue for LLMAIX2001a;
+- one research evidence issue;
+- one community recap draft.
+
+### Draft announcement pack: GitHub, GitLab, Bitbucket, Telegram, Discord, X
+
+Status tags: `area:community`, `status:draft`, `needs:approval`
+
+Output:
+
+- GitHub Discussion draft;
+- GitLab issue or project update draft;
+- Bitbucket issue update draft;
+- Telegram short post draft;
+- Discord announcement draft;
+- X thread draft.
+
+### Evidence pack: 2017 ABC4RD origin and 2026 global Bitcoin education context
+
+Status tags: `area:research`, `needs:evidence`, `priority:high`
+
+Output:
+
+- compact citation block;
+- reusable safe wording for repository pages;
+- source-backed partner brief paragraph;
+- rejection list for claims that require private confirmation.

--- a/docs/discussions.md
+++ b/docs/discussions.md
@@ -14,4 +14,3 @@ Enable GitHub Discussions for the organization-facing repositories and create th
 ## Setup notes
 
 GitHub does not fully manage Discussions categories through normal repository files. Treat this document as the source of truth, then create categories manually in repository settings or with approved GitHub API commands after `gh auth login`.
-

--- a/docs/event-activation-pipeline.md
+++ b/docs/event-activation-pipeline.md
@@ -1,0 +1,48 @@
+# Event Activation Pipeline
+
+ABC4RD can use conferences and community events as public learning anchors. The
+goal is not noisy outreach. The goal is to turn each event into a useful course,
+research, or community artifact.
+
+## Intake checklist
+
+For every event target, open an event activation issue and capture:
+
+- event name and public website;
+- dates and location, verified from the official event page;
+- relevant tracks, speakers, sponsors, or workshops;
+- ABC4RD education angle;
+- linked course module, lab, article, or research note;
+- publication and outreach approval status.
+
+## Activation levels
+
+| Level | Action | Approval |
+| --- | --- | --- |
+| Watch | Track event and collect public sources | Maintainer review |
+| Draft | Prepare article, thread, workshop, or partner note | Human approval required |
+| Engage | Send approved outreach or community invitation | Human approval required |
+| Publish | Share recap, module, or learning artifact | Human approval required |
+
+## Suggested issue titles
+
+- `Event watch: [Event] - [education angle]`
+- `Workshop draft: [Topic] for [Event/community]`
+- `Partner note: [Organization] - [course/research connection]`
+- `Recap draft: [Event] - [learning output]`
+
+## Outreach boundaries
+
+- Do not claim partnership, sponsorship, endorsement, or approval unless confirmed.
+- Do not mass-invite people or post repetitive messages.
+- Do not send private credentials, internal notes, or unpublished contracts.
+- Keep each message tied to a concrete learning artifact people can inspect.
+
+## Useful outputs
+
+- beginner issue for a course module;
+- short research source review;
+- event-specific workshop outline;
+- multilingual learning note;
+- partner brief draft;
+- community recap after human review.

--- a/docs/frontier-innovation-strategy.md
+++ b/docs/frontier-innovation-strategy.md
@@ -1,0 +1,82 @@
+# Frontier Innovation Strategy
+
+Updated: 2026-05-06
+
+ABC4RD Academy should be visible as an education initiative that understands
+where AI is moving now: agentic systems, AGI readiness, ASI safety, and
+blockchain-backed trust infrastructure.
+
+This is a research and education strategy. It does not claim that ABC4RD has
+built AGI or ASI.
+
+## Public thesis
+
+ABC4RD connects four learning layers:
+
+1. AI foundations: language models, reasoning, tools, multimodal workflows.
+2. AI agents: systems that can plan, call tools, inspect files, run code, and
+   ask for human approval before public actions.
+3. AGI and ASI literacy: safety, evaluations, alignment, governance, and
+   responsible deployment.
+4. Blockchain trust: credentials, provenance, attestations, public bounties, and
+   transparent contributor incentives.
+
+## Workstreams
+
+| Workstream | Repository | Public output |
+| --- | --- | --- |
+| Flagship AI course | `LLMAIX2001a` | Module map, labs, agent demos, innovation agenda |
+| Evidence and claims | `abc4rd-research` | Source maps, citation packs, safety notes |
+| Community operations | `abc4rd-community` | Contributor onboarding, events, governance |
+| Main hub | `ABC4RD` | Roadmap, issue backlog, partner-safe public narrative |
+
+## AI agents
+
+Near-term innovation should focus on agent workflows that learners can inspect:
+
+- research assistants with source-backed outputs;
+- course-maintainer agents that draft issues from module gaps;
+- code-lab agents that run tests in sandboxes;
+- approval-gated publishing agents that prepare drafts but cannot post alone.
+
+## AGI
+
+AGI should be framed as a research literacy track:
+
+- definitions and uncertainty;
+- capability and autonomy evaluations;
+- preparedness frameworks;
+- agentic oversight;
+- privacy-preserving safety methods;
+- governance and auditability.
+
+## ASI
+
+ASI should be framed as safety literacy:
+
+- alignment problem fundamentals;
+- scalable oversight;
+- model-assisted evaluation;
+- robustness and interpretability;
+- red-team practices;
+- staged deployment and emergency response.
+
+## Blockchain integration
+
+Blockchain belongs where it improves trust:
+
+- verifiable learning credentials;
+- signed release attestations;
+- dataset and source provenance;
+- transparent grants and contributor bounties;
+- Bitcoin, Lightning, and Nostr education workflows;
+- audit trails for agent-assisted publication.
+
+## Source notes
+
+- [OpenAI Agents SDK](https://platform.openai.com/docs/guides/agents-sdk/)
+- [OpenAI Agents SDK evolution](https://openai.com/index/the-next-evolution-of-the-agents-sdk)
+- [Anthropic Model Context Protocol](https://www.anthropic.com/research/model-context-protocol)
+- [W3C Verifiable Credentials Data Model v2.0](https://www.w3.org/TR/vc-data-model/)
+- [OpenAI Preparedness Framework](https://openai.com/index/updating-our-preparedness-framework/)
+- [OpenAI Safety Fellowship](https://openai.com/index/introducing-openai-safety-fellowship/)

--- a/docs/github-issue-backlog.md
+++ b/docs/github-issue-backlog.md
@@ -1,0 +1,100 @@
+# GitHub Issue Backlog
+
+These issue drafts are ready to convert into GitHub issues after maintainer
+review. Keep each issue small enough to complete with a pull request or a clear
+published artifact.
+
+## Priority issues
+
+### Build the public website information architecture
+
+Labels: `area:site`, `priority:high`, `status:draft`
+
+Output:
+
+- sitemap for About, Courses, Research, Evidence, Community, and Contact;
+- source-backed copy blocks for each page;
+- list of required assets and OpenGraph images.
+
+### Create the first learner pathway for LLMAIX2001a
+
+Labels: `area:ai-education`, `priority:high`, `help wanted`
+
+Output:
+
+- module sequence for beginners;
+- one good first issue per module;
+- link from `ABC4RD` to the course repository roadmap.
+
+### Prepare the research citation pack
+
+Labels: `area:research`, `needs:evidence`, `priority:high`
+
+Output:
+
+- verified source list for the 2017 public origin;
+- safe wording for Bitcoin Magazine and Nasdaq references;
+- reusable citation block for README, website, and partner briefs.
+
+### Launch the weekly community recap draft
+
+Labels: `area:community`, `status:draft`, `needs:approval`
+
+Output:
+
+- Friday recap template;
+- first draft recap based only on merged PRs, opened issues, and approved docs;
+- approval checklist before posting to Telegram, Discord, or X.
+
+### Open the first event watch issue
+
+Labels: `area:events`, `needs:evidence`, `needs:approval`
+
+Output:
+
+- official event source link;
+- ABC4RD education angle;
+- linked course, workshop, or article draft;
+- clear decision on watch, draft, engage, or publish level.
+
+### Define partner brief review rules
+
+Labels: `area:partners`, `needs:approval`, `needs:evidence`
+
+Output:
+
+- partner brief checklist;
+- safe language examples;
+- rejection list for unverified partnership claims.
+
+## Contributor-friendly issues
+
+### Add glossary entries for beginner learners
+
+Labels: `good first issue`, `area:bitcoin-education`, `help wanted`
+
+Output:
+
+- 10 beginner-friendly glossary entries;
+- one public source per technical term where useful;
+- links to course modules when available.
+
+### Translate the public positioning paragraph
+
+Labels: `good first issue`, `area:community`, `help wanted`
+
+Output:
+
+- translations for the short ABC4RD positioning paragraph;
+- language review checklist;
+- no new claims beyond the approved English source text.
+
+### Review community channel descriptions
+
+Labels: `good first issue`, `area:community`
+
+Output:
+
+- concise channel purpose for Telegram, Discord, and GitHub Discussions;
+- one recommended moderation boundary per channel;
+- links updated in the main README if needed.

--- a/docs/github-issue-backlog.md
+++ b/docs/github-issue-backlog.md
@@ -26,6 +26,17 @@ Output:
 - one good first issue per module;
 - link from `ABC4RD` to the course repository roadmap.
 
+### Publish the frontier innovation strategy
+
+Labels: `area:ai-education`, `area:research`, `needs:evidence`
+
+Output:
+
+- source-backed public thesis for AI agents, AGI, ASI, and blockchain trust;
+- link from the main README;
+- matching issue set in `LLMAIX2001a`;
+- safe wording that avoids claiming existing AGI or ASI.
+
 ### Prepare the research citation pack
 
 Labels: `area:research`, `needs:evidence`, `priority:high`

--- a/docs/github-roadmap.md
+++ b/docs/github-roadmap.md
@@ -17,6 +17,8 @@ This roadmap prepares ABC4RDacademy for public development without leaking priva
 - Add concise repository descriptions and topics.
 - Enable Issues and Discussions.
 - Create the six discussion categories listed in `docs/discussions.md`.
+- Apply the shared label set from `.github/labels.yml`.
+- Use the pull request template for source discipline and safety checks.
 
 ## Phase 3: Content pipeline
 
@@ -47,6 +49,7 @@ This roadmap prepares ABC4RDacademy for public development without leaking priva
 - Open one event issue per opportunity.
 - Connect every event target to a course, workshop, article, or learning module.
 - Avoid claiming partnership unless confirmed publicly or by approved written agreement.
+- Use `docs/event-activation-pipeline.md` before outreach or publication.
 
 ## Phase 7: Open-source course development
 
@@ -56,3 +59,11 @@ This roadmap prepares ABC4RDacademy for public development without leaking priva
 - Use public pull requests for course content, labs, translations, and evidence updates.
 - Publish milestone notes quarterly.
 
+## Platform expansion
+
+- Use GitHub as the public source of truth until maintainers approve a migration.
+- Use GitLab for controlled mirrors, sprint boards, and validation experiments.
+- Use Bitbucket for Atlassian-facing mirrors, partner review, branch restrictions,
+  pull request templates, and starter issue queues.
+- Keep external outreach draft-only until a maintainer approves the target list
+  and message text.

--- a/docs/gitlab-activation.md
+++ b/docs/gitlab-activation.md
@@ -1,0 +1,89 @@
+# GitLab Activation
+
+This playbook describes how ABC4RD can use GitLab without fragmenting the public project or leaking credentials.
+
+## Operating decision
+
+Keep GitHub as the current source of truth until a formal migration is approved. Use GitLab for one of these controlled roles:
+
+- public mirror for discoverability;
+- private planning workspace for maintainers;
+- CI/CD experiment space;
+- partner-facing review copy;
+- issue board for a specific event or course sprint.
+
+Do not run bidirectional repository mirroring unless the maintainers have a written conflict-resolution plan.
+
+## Immediate setup
+
+1. Create or identify the GitLab namespace for ABC4RD Academy.
+2. Create the `ABC4RD` project with the same description, topics, license, and README positioning as the GitHub repository.
+3. Add a `gitlab` remote locally only after the project URL is confirmed.
+4. Push the protected `main` branch and tags.
+5. Configure protected branches, required merge request approvals, and default issue labels before inviting contributors.
+6. Store tokens only in GitLab CI/CD variables or local ignored environment files.
+
+The local bootstrap script is [scripts/gitlab-bootstrap.ps1](../scripts/gitlab-bootstrap.ps1). It reads `GITLAB_TOKEN`, `GITLAB_HOST`, `GITLAB_NAMESPACE`, and project settings from environment variables or a local ignored `.env` file.
+
+Example:
+
+```powershell
+$env:GITLAB_TOKEN = "<fresh-token-from-local-secret-store>"
+$env:GITLAB_NAMESPACE = "abc4rd-academy"
+.\scripts\gitlab-bootstrap.ps1 -CreateProject -ConfigureProject -AddRemote -CreateStarterIssues
+```
+
+Use `-Push` only after the remote URL and project settings are reviewed.
+
+## Activity model
+
+Use GitLab activity for concrete, reviewable work:
+
+- one milestone per public sprint;
+- one issue board per course, event, or partner track;
+- merge requests for documentation and curriculum changes;
+- labels for `course`, `research`, `community`, `event`, `partner`, `security`, and `good first issue`;
+- monthly public recap issues that link back to merged work.
+
+Starter issue drafts are maintained in [docs/gitlab-starter-issues.md](gitlab-starter-issues.md).
+
+## Outreach guardrails
+
+Invitations, subscriptions, and external events should be done from an approved account and after human review.
+
+Before any external action, record:
+
+- target person, group, company, or event;
+- public reason ABC4RD should engage;
+- proposed message;
+- expected follow-up owner;
+- risk level if the target interprets the message as a partnership claim.
+
+## Token handling
+
+Treat any token pasted into chat, email, or an issue as exposed. Revoke it and create a fresh token with the minimum required scopes.
+
+Recommended token usage:
+
+- `read_api` or `read_repository` for audits;
+- `write_repository` only for pushing code;
+- `api` only when project creation, labels, issues, or settings must be automated;
+- short expiration dates for all automation tokens.
+
+## First seven days
+
+| Day | Action | Output |
+| --- | --- | --- |
+| 1 | Confirm namespace and repository URL | `gitlab` remote plan |
+| 2 | Publish mirror or initial project | visible project with safe README |
+| 3 | Add labels, milestones, protected branches | project governance baseline |
+| 4 | Open starter issues | course, research, community, event tasks |
+| 5 | Create first merge request | small documentation improvement |
+| 6 | Draft partner/event outreach | reviewed messages only |
+| 7 | Publish recap | public issue or discussion with next steps |
+
+## Sources
+
+- [GitLab repository mirroring](https://docs.gitlab.com/user/project/repository/mirror/)
+- [GitLab projects API](https://docs.gitlab.com/api/projects/)
+- [GitLab personal access tokens](https://docs.gitlab.com/user/profile/personal_access_tokens/)

--- a/docs/gitlab-starter-issues.md
+++ b/docs/gitlab-starter-issues.md
@@ -1,0 +1,58 @@
+# GitLab Starter Issues
+
+These issues are ready to create in GitLab after the project URL and token are configured.
+
+## Priority issues
+
+### Publish ABC4RD as a controlled GitLab mirror
+
+Labels: `area:site`, `priority:high`, `status:review`
+
+Output:
+
+- GitLab project URL recorded in `docs/gitlab-activation.md`;
+- `gitlab` remote added without credentials in the URL;
+- protected `main` branch;
+- first successful validation pipeline.
+
+### Create the first GitLab issue board
+
+Labels: `area:community`, `priority:high`, `status:draft`
+
+Output:
+
+- board columns for draft, review, approved, published, and archived;
+- labels aligned with `.github/labels.yml`;
+- one issue per active workstream.
+
+### Open the first event watch issue
+
+Labels: `area:events`, `needs:evidence`, `needs:approval`
+
+Output:
+
+- official event source link;
+- ABC4RD education angle;
+- linked course, workshop, or article draft;
+- clear decision on watch, draft, engage, or publish level.
+
+### Create LLMAIX2001a learner pathway issue
+
+Labels: `area:ai-education`, `good first issue`, `help wanted`
+
+Output:
+
+- beginner pathway outline;
+- first three module issues;
+- link to the LLMAIX2001a roadmap.
+
+### Draft the first partner outreach message
+
+Labels: `area:partners`, `needs:approval`, `status:draft`
+
+Output:
+
+- target and public reason for outreach;
+- draft-only message;
+- approval checklist;
+- follow-up owner.

--- a/docs/operating-loop.md
+++ b/docs/operating-loop.md
@@ -1,0 +1,49 @@
+# ABC4RD Operating Loop
+
+This loop turns the organization roadmap into visible weekly repository activity
+across GitHub, GitLab, and Bitbucket while keeping public claims source-backed
+and human-approved.
+
+## Weekly rhythm
+
+| Day | Action | Output |
+| --- | --- | --- |
+| Monday | Review open issues and pick one priority per workstream | Updated labels, owners, and next actions |
+| Tuesday | Advance one course or research item | Pull request, source note, or module outline |
+| Wednesday | Draft one partner, event, or community activation | Issue with sources, angle, and approval gate |
+| Thursday | Improve public onboarding | README, contribution path, or good first issue |
+| Friday | Publish a repository recap draft | Human-reviewed post draft for GitHub, GitLab, Bitbucket, Telegram, Discord, or X |
+
+## Workstream board
+
+| Workstream | Primary repository | Healthy weekly signal |
+| --- | --- | --- |
+| Main hub | `ABC4RD` | Roadmap, issues, docs, website direction |
+| AI course | `LLMAIX2001a` | Module outlines, labs, translations, learner issues |
+| Research | `abc4rd-research` | Source reviews, citation maps, media-kit updates |
+| Community | `abc4rd-community` | Onboarding, governance, event playbooks |
+| Organization profile | `.github` | Clear public profile and pinned repository narrative |
+
+## Issue flow
+
+1. Open a focused issue from an existing template.
+2. Add area, status, and needs labels.
+3. Link at least one repository source or public reference.
+4. Define the useful output: doc, PR, draft post, module, event note, or partner brief.
+5. Move to review before any external publication or outreach.
+
+## Platform sync
+
+| Platform | Role | Required signal |
+| --- | --- | --- |
+| GitHub | Public source of truth | Issues, Discussions, pull requests, labels, pinned repositories |
+| GitLab | Controlled mirror or sprint workspace | Protected branch, issue board, validation pipeline |
+| Bitbucket | Atlassian-facing mirror or partner review workspace | Branch restrictions, starter issues, PR template, validation pipeline |
+
+## Public activity rules
+
+- Prefer steady useful updates over broad promotion.
+- Use issues and pull requests as the public work trail.
+- Keep Telegram, Discord, X, and partner messages as drafts until approved.
+- Record published links back into the relevant issue.
+- Rotate credentials immediately if any secret appears in chat, logs, commits, or screenshots.

--- a/docs/organization-structure.md
+++ b/docs/organization-structure.md
@@ -22,6 +22,17 @@ Evidence and public research repository. It should hold citation maps, source re
 
 Community and governance repository. It should hold the public charter, governance model, community operations, event playbooks, and contribution pathways.
 
+## Platform mirrors
+
+GitHub remains the current public source of truth. GitLab and Bitbucket may be
+used as controlled mirrors, sprint workspaces, partner review spaces, or CI/CD
+experiments after credentials and permissions are approved.
+
+- GitHub: organization profile, public issues, discussions, pull requests.
+- GitLab: issue board, protected branch, validation pipeline, starter issues.
+- Bitbucket: repository page, branch restrictions, PR template, starter issues,
+  and Atlassian-facing review flow.
+
 ## Operating model
 
 - Keep content work public when possible.
@@ -30,4 +41,3 @@ Community and governance repository. It should hold the public charter, governan
 - Use discussions for broad community work.
 - Use pull requests for reviewable changes.
 - Keep public claims tied to sources.
-

--- a/docs/outreach-drafts.md
+++ b/docs/outreach-drafts.md
@@ -1,0 +1,107 @@
+# Outreach Drafts
+
+Use these drafts as starting points only. Replace bracketed fields, attach a
+source-backed learning artifact, and get maintainer approval before sending.
+
+## Event organizer draft
+
+Subject: ABC4RD education note for [event name]
+
+Hello [name/team],
+
+ABC4RD Academy is rebuilding an international blockchain and AI education
+initiative with a public 2017 media trail through Bitcoin Magazine and Nasdaq.
+We are preparing source-backed learning materials around Bitcoin education,
+open-source contribution, AI literacy, mining and compute infrastructure, and
+community learning.
+
+For [event name], we would like to prepare a small education artifact:
+[workshop outline / learner pathway / research note / translation sprint]. The
+goal is useful public learning material, not a partnership claim.
+
+Could we send a short draft for your review?
+
+Best,
+[sender]
+
+## Education partner draft
+
+Subject: Draft learning collaboration idea from ABC4RD Academy
+
+Hello [name/team],
+
+We are developing ABC4RD Academy as an open education hub for AI, Bitcoin,
+open-source contribution, green compute, digital credentials, and community
+learning. A current focus is turning public research and course material into
+small learner-ready modules.
+
+Your work on [specific public topic] connects well with [course/research/event
+artifact]. We would like to propose a lightweight first step: a guest learning
+note, reviewed source list, workshop outline, or public issue that learners can
+contribute to.
+
+If this is relevant, we can share a one-page draft.
+
+Best,
+[sender]
+
+## Open-source maintainer draft
+
+Subject: Beginner learning issue around [project/topic]
+
+Hello [name/team],
+
+ABC4RD Academy is preparing beginner-friendly pathways into Bitcoin and AI open
+source. We are not asking for endorsement. We want to help learners understand
+how to read public docs, follow contribution norms, and make small useful
+improvements.
+
+We are drafting a learning issue around [project/topic] and would appreciate a
+quick pointer to the best public contributor docs or beginner-safe tasks.
+
+Best,
+[sender]
+
+## Community recap draft
+
+ABC4RD weekly draft recap:
+
+- Main hub: [merged PR / opened issue / reviewed doc]
+- Course: [LLMAIX2001a or Bitcoin module progress]
+- Research: [source or evidence note]
+- Community: [discussion, onboarding, moderation, channel update]
+- Events and partners: [draft-only watch item]
+
+Next: [one concrete approved action]
+
+## Telegram short draft
+
+ABC4RD Academy is organizing the relaunch work into public repositories,
+source-backed research, course modules, and draft-first community updates.
+
+This week: [one concrete repository update].
+
+Draft-first rule: no public partnership claims without confirmation.
+
+## Discord announcement draft
+
+ABC4RD update:
+
+The project now has a clearer operating loop for courses, research, community,
+events, and partner drafts. Current work is moving through issues and pull
+requests so contributors can inspect the trail and join safely.
+
+Priority this week: [issue or PR link].
+
+## X thread draft
+
+1. ABC4RD Academy is rebuilding as an international blockchain and AI education
+initiative.
+
+2. The work is organized around public repositories, course modules,
+source-backed research, community learning, and draft-first publishing.
+
+3. Current focus: [specific update].
+
+4. We welcome careful contributors: source review, learning modules,
+translations, event notes, and open-source onboarding.

--- a/docs/partner-activity-queue.md
+++ b/docs/partner-activity-queue.md
@@ -1,0 +1,50 @@
+# Partner Activity Queue
+
+This queue turns partner, event, and community ideas into reviewable work. It is
+not a permission to mass-message people, subscribe from personal accounts, or
+claim partnership. Every external action needs an approved target and message.
+
+## Operating rules
+
+- Start with public sources, not private assumptions.
+- Share a learning artifact, not a vague pitch.
+- Keep the first step small: watch, draft, review, then engage.
+- Record every public URL, draft, reply, and follow-up in an issue.
+- Do not imply sponsorship, endorsement, affiliation, or official partnership
+  unless it is publicly confirmed or approved in writing.
+
+## Near-term targets
+
+| Target | Why it matters | First ABC4RD action | Approval level |
+| --- | --- | --- | --- |
+| BTC Inc / B.tc | Parent ecosystem for Bitcoin Magazine, The Bitcoin Conference, and Bitcoin for Corporations | Draft source-backed education brief | Review |
+| Bitcoin 2026 Las Vegas | Major global Bitcoin event with education, open-source, mining, and enterprise angles | Event watch issue and workshop outline | Review |
+| Bitcoin Asia / Hong Kong | Regional bridge for localization, adoption, and education | Event watch issue and translation sprint concept | Review |
+| Bitcoin Amsterdam | European education and university outreach angle | Event watch issue and EU learning note | Review |
+| Bitcoin MENA / Abu Dhabi | Mining, energy, AI compute, and sovereign adoption themes | Event watch issue and compute literacy brief | Review |
+| Bitcoin for Corporations | Corporate Bitcoin education and executive learning context | Executive education note draft | Review |
+| Bitcoin Magazine Japan / Metaplanet | Public example of Bitcoin media plus education/adoption localization | Japan localization source review | Review |
+| Bitcoin Core | Open-source learner pathway anchor | Beginner contribution reading issue | Review |
+| Lightning Development Kit | Lightning developer education anchor | Module source review issue | Review |
+| BTCPay Server | Practical Bitcoin infrastructure and merchant education | Lab idea draft | Review |
+| Bitcoin Design Guide | Wallet and product literacy | UX learning issue | Review |
+| Mastering Bitcoin | Foundational learner reference | Reading pathway issue | Review |
+
+## Weekly action mix
+
+| Workstream | Weekly output |
+| --- | --- |
+| Events | One watch issue with official sources and education angle |
+| Partners | One draft outreach message tied to a source-backed artifact |
+| Community | One recap draft for Telegram, Discord, X, and repository updates |
+| Course | One LLMAIX2001a or Bitcoin education module issue |
+| Research | One source review or citation block improvement |
+
+## Review checklist before engagement
+
+- Target is publicly identifiable.
+- Message is short and specific.
+- ABC4RD claim language is source-backed.
+- The shared artifact is public or approved for sharing.
+- Follow-up owner is named.
+- Risk is low if the target reads the message as a public statement.

--- a/docs/partner-brief.md
+++ b/docs/partner-brief.md
@@ -31,4 +31,3 @@ ABC4RD Academy is an international blockchain and AI education initiative buildi
 ## Public language boundary
 
 ABC4RD does not claim partner status unless it is publicly confirmed or approved in writing. Partner leads should be tracked as proposals until confirmed.
-

--- a/docs/publishing-safety.md
+++ b/docs/publishing-safety.md
@@ -68,4 +68,3 @@ Avoid unless formally confirmed:
 - "sponsored by";
 - "working with BTC Inc";
 - "approved by Bitcoin Magazine".
-

--- a/scripts/gitlab-bootstrap.ps1
+++ b/scripts/gitlab-bootstrap.ps1
@@ -1,0 +1,242 @@
+param(
+  [string]$EnvFile = ".env",
+  [string]$HostUrl,
+  [string]$Token,
+  [string]$Namespace,
+  [string]$ProjectPath,
+  [string]$ProjectName,
+  [switch]$CreateProject,
+  [switch]$ConfigureProject,
+  [switch]$AddRemote,
+  [switch]$Push,
+  [switch]$CreateStarterIssues
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($EnvFile -and (Test-Path -LiteralPath $EnvFile)) {
+  Get-Content -LiteralPath $EnvFile | ForEach-Object {
+    if ($_ -match '^\s*#') { return }
+    if ($_ -match '^\s*$') { return }
+    if ($_ -match '^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)\s*$') {
+      $name = $Matches[1]
+      $value = $Matches[2].Trim()
+      if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+        $value = $value.Substring(1, $value.Length - 2)
+      }
+      if (-not [Environment]::GetEnvironmentVariable($name, "Process")) {
+        [Environment]::SetEnvironmentVariable($name, $value, "Process")
+      }
+    }
+  }
+}
+
+if (-not $HostUrl) { $HostUrl = $env:GITLAB_HOST }
+if (-not $Token) { $Token = $env:GITLAB_TOKEN }
+if (-not $Namespace) { $Namespace = $env:GITLAB_NAMESPACE }
+if (-not $ProjectPath) { $ProjectPath = $(if ($env:GITLAB_PROJECT_PATH) { $env:GITLAB_PROJECT_PATH } else { "ABC4RD" }) }
+if (-not $ProjectName) { $ProjectName = $(if ($env:GITLAB_PROJECT_NAME) { $env:GITLAB_PROJECT_NAME } else { "ABC4RD" }) }
+
+if (-not $HostUrl) { $HostUrl = "https://gitlab.com" }
+$HostUrl = $HostUrl.TrimEnd("/")
+$ApiUrl = "$HostUrl/api/v4"
+
+if (-not $Token) {
+  throw "Set GITLAB_TOKEN in the environment. Do not commit tokens or put them in remote URLs."
+}
+
+function Invoke-GitLab {
+  param(
+    [string]$Method,
+    [string]$Path,
+    [object]$Body = $null
+  )
+
+  $headers = @{ "PRIVATE-TOKEN" = $Token }
+  $uri = "$ApiUrl$Path"
+
+  if ($null -eq $Body) {
+    return Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers
+  }
+
+  return Invoke-RestMethod -Method $Method -Uri $uri -Headers $headers -ContentType "application/json" -Body ($Body | ConvertTo-Json -Depth 10)
+}
+
+function Get-Project {
+  param([string]$FullPath)
+  $encoded = [uri]::EscapeDataString($FullPath)
+  try {
+    return Invoke-GitLab -Method "GET" -Path "/projects/$encoded"
+  } catch {
+    return $null
+  }
+}
+
+function Ensure-Label {
+  param(
+    [int]$ProjectId,
+    [string]$Name,
+    [string]$Color,
+    [string]$Description
+  )
+
+  try {
+    Invoke-GitLab -Method "POST" -Path "/projects/$ProjectId/labels" -Body @{
+      name = $Name
+      color = $Color
+      description = $Description
+    } | Out-Null
+  } catch {
+    Invoke-GitLab -Method "PUT" -Path "/projects/$ProjectId/labels/$([uri]::EscapeDataString($Name))" -Body @{
+      new_name = $Name
+      color = $Color
+      description = $Description
+    } | Out-Null
+  }
+}
+
+function Ensure-Milestone {
+  param(
+    [int]$ProjectId,
+    [string]$Title,
+    [string]$Description
+  )
+
+  $milestones = Invoke-GitLab -Method "GET" -Path "/projects/$ProjectId/milestones?search=$([uri]::EscapeDataString($Title))"
+  if (-not ($milestones | Where-Object { $_.title -eq $Title })) {
+    Invoke-GitLab -Method "POST" -Path "/projects/$ProjectId/milestones" -Body @{
+      title = $Title
+      description = $Description
+    } | Out-Null
+  }
+}
+
+$me = Invoke-GitLab -Method "GET" -Path "/user"
+Write-Host "Authenticated as GitLab user: $($me.username)"
+
+if (-not $Namespace) {
+  $Namespace = $me.username
+  Write-Host "GITLAB_NAMESPACE was not set. Using user namespace: $Namespace"
+}
+
+$fullPath = "$Namespace/$ProjectPath"
+$project = Get-Project -FullPath $fullPath
+
+if (-not $project -and $CreateProject) {
+  $body = @{
+    name = $ProjectName
+    path = $ProjectPath
+    visibility = "public"
+    description = "ABC4RD Academy public hub for blockchain and AI education."
+    issues_access_level = "enabled"
+    merge_requests_access_level = "enabled"
+    wiki_access_level = "disabled"
+    snippets_access_level = "disabled"
+    initialize_with_readme = $false
+  }
+
+  if ($Namespace -ne $me.username) {
+    $namespaces = Invoke-GitLab -Method "GET" -Path "/namespaces?search=$([uri]::EscapeDataString($Namespace))"
+    $target = $namespaces | Where-Object { $_.full_path -eq $Namespace } | Select-Object -First 1
+    if (-not $target) { throw "Namespace '$Namespace' was not found or is not accessible." }
+    $body.namespace_id = $target.id
+  }
+
+  $project = Invoke-GitLab -Method "POST" -Path "/projects" -Body $body
+}
+
+if (-not $project) {
+  throw "Project '$fullPath' does not exist or is not accessible. Re-run with -CreateProject or set GITLAB_NAMESPACE/GITLAB_PROJECT_PATH."
+}
+
+Write-Host "GitLab project: $($project.web_url)"
+
+if ($ConfigureProject) {
+  $labels = @(
+    @{ name = "area:ai-education"; color = "#1d76db"; description = "AI course, labs, literacy, and learning pathway work." },
+    @{ name = "area:bitcoin-education"; color = "#f9d0c4"; description = "Bitcoin, Lightning, Nostr, custody, mining, and treasury education." },
+    @{ name = "area:community"; color = "#0e8a16"; description = "Community operations, governance, onboarding, and public support." },
+    @{ name = "area:events"; color = "#fbca04"; description = "Conferences, workshops, meetups, and event activation." },
+    @{ name = "area:partners"; color = "#5319e7"; description = "Partner mapping, outreach drafts, and collaboration opportunities." },
+    @{ name = "area:research"; color = "#0052cc"; description = "Evidence, citation review, source maps, and media-kit materials." },
+    @{ name = "area:site"; color = "#c2e0c6"; description = "Website, docs navigation, OpenGraph, and publishing integration." },
+    @{ name = "good first issue"; color = "#7057ff"; description = "Small, clear task suitable for a first public contribution." },
+    @{ name = "help wanted"; color = "#008672"; description = "Task where public contributor support is welcome." },
+    @{ name = "needs:approval"; color = "#b60205"; description = "Requires human approval before external publication or outreach." },
+    @{ name = "needs:evidence"; color = "#d93f0b"; description = "Needs public source review before claims can be treated as factual." },
+    @{ name = "priority:high"; color = "#b60205"; description = "Important near-term work for public credibility or operations." },
+    @{ name = "status:draft"; color = "#ededed"; description = "Draft work that is not ready for public publication." },
+    @{ name = "status:review"; color = "#fbca04"; description = "Ready for source, editorial, or maintainer review." }
+  )
+
+  foreach ($label in $labels) {
+    Ensure-Label -ProjectId $project.id -Name $label.name -Color $label.color -Description $label.description
+  }
+
+  Ensure-Milestone -ProjectId $project.id -Title "Activation Sprint 1" -Description "First GitLab mirror, governance baseline, starter issues, and approved outreach drafts."
+
+  try {
+    Invoke-GitLab -Method "POST" -Path "/projects/$($project.id)/protected_branches" -Body @{
+      name = "main"
+      push_access_level = 40
+      merge_access_level = 40
+      allow_force_push = $false
+    } | Out-Null
+  } catch {
+    Write-Host "Protected branch 'main' already exists or could not be changed with this token."
+  }
+}
+
+if ($CreateStarterIssues) {
+  $issues = @(
+    @{
+      title = "Publish ABC4RD as a controlled GitLab mirror"
+      labels = "area:site,priority:high,status:review"
+      description = "Output:`n- GitLab project URL recorded in docs/gitlab-activation.md.`n- gitlab remote added without credentials in the URL.`n- protected main branch.`n- first successful validation pipeline."
+    },
+    @{
+      title = "Create the first GitLab issue board"
+      labels = "area:community,priority:high,status:draft"
+      description = "Output:`n- Board columns for draft, review, approved, published, and archived.`n- Labels aligned with .github/labels.yml.`n- One issue per active workstream."
+    },
+    @{
+      title = "Open the first event watch issue"
+      labels = "area:events,needs:evidence,needs:approval"
+      description = "Output:`n- Official event source link.`n- ABC4RD education angle.`n- Linked course, workshop, or article draft.`n- Clear decision on watch, draft, engage, or publish level."
+    },
+    @{
+      title = "Create LLMAIX2001a learner pathway issue"
+      labels = "area:ai-education,good first issue,help wanted"
+      description = "Output:`n- Beginner pathway outline.`n- First three module issues.`n- Link to the LLMAIX2001a roadmap."
+    },
+    @{
+      title = "Draft the first partner outreach message"
+      labels = "area:partners,needs:approval,status:draft"
+      description = "Output:`n- Target and public reason for outreach.`n- Draft-only message.`n- Approval checklist.`n- Follow-up owner."
+    }
+  )
+
+  foreach ($issue in $issues) {
+    $existing = Invoke-GitLab -Method "GET" -Path "/projects/$($project.id)/issues?search=$([uri]::EscapeDataString($issue.title))"
+    if (-not ($existing | Where-Object { $_.title -eq $issue.title })) {
+      Invoke-GitLab -Method "POST" -Path "/projects/$($project.id)/issues" -Body $issue | Out-Null
+    }
+  }
+}
+
+if ($AddRemote) {
+  $remoteUrl = $project.http_url_to_repo
+  $existingRemote = git remote
+  if ($existingRemote -contains "gitlab") {
+    git remote set-url gitlab $remoteUrl
+  } else {
+    git remote add gitlab $remoteUrl
+  }
+  Write-Host "Configured gitlab remote: $remoteUrl"
+}
+
+if ($Push) {
+  git push gitlab main --tags
+}
+
+Write-Host "Done."


### PR DESCRIPTION
## Summary

- add platform activation docs for GitHub, GitLab, and Bitbucket
- add PR and issue process infrastructure
- add operating loop, event activation pipeline, partner activity queue, and outreach draft guardrails
- add GitLab bootstrap script and cross-platform starter guidance
- add frontier innovation strategy for AI agents, AGI literacy, ASI safety, and blockchain trust

## Safety

- keeps outreach draft-first and human-approved
- reinforces least-privilege token handling and credential rotation
- avoids verified partnership claims unless publicly confirmed or approved
- frames AGI and ASI as education, safety, and governance topics, not as existing ABC4RD capabilities

## Public activation

Starter issues opened from this direction:

- #5 Publish frontier innovation strategy for ABC4RD
- #6 Design the blockchain trust layer for credentials and provenance
- #7 Create an approval-gated AI agent operating policy