### PR TITLE
Fix site header brand contrast

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,7 @@
       display: inline-flex;
       align-items: center;
       gap: 10px;
+      color: white;
       font-weight: 700;
       letter-spacing: 0;
     }


### PR DESCRIPTION
## Summary

- fix the header brand text contrast on the dark hero image

## Validation

- npx markdownlint-cli2 "**/*.md"
- git diff --check
