### PR TITLE
Add financial model map

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Use this carefully:
 - [International Academy Baseline milestone](docs/milestones/launch-sprint-01-international-academy-baseline.md)
 - [Operating Discipline milestone](docs/milestones/launch-sprint-02-operating-discipline.md)
 - [Financial Model v1 milestone](docs/milestones/financial-model-v1.md)
+- [Financial model map v1](docs/finance/financial-model-map-v1.md)
 - [ABC4RD Academy Financial Model v1](docs/financial-model-v1.md)
 - [Financial decision log v1](docs/finance/decision-log-v1.md)
 - [Money flow v1](docs/finance/money-flow-v1.md)

--- a/docs/finance/financial-model-map-v1.md
+++ b/docs/finance/financial-model-map-v1.md
@@ -1,0 +1,580 @@
+# Financial Model Map v1
+
+Status: operating map. English is the canonical repository language.
+
+This map shows where every part of the ABC4RD Academy financial model belongs.
+Use it as the top-level picture before editing pricing, payments, treasury,
+language packaging, or revenue issues.
+
+## 1. Executive Picture
+
+ABC4RD Academy starts as a focused education business, not a token project and
+not a general consulting shop.
+
+The first commercial model is:
+
+```text
+Public trust layer
+  -> free self-study entry
+  -> paid Blockchain Foundations cohort
+  -> optional certificate review
+  -> institutional starter package
+  -> scholarships, sponsorships, and grants
+```
+
+Default rule:
+
+- one flagship course;
+- one certificate review workflow;
+- one institutional starter offer;
+- fiat first;
+- crypto only as a reviewed pilot;
+- language groups before territory-specific selling.
+
+## 2. Operating Boundaries
+
+### 2.1 What ABC4RD Sells
+
+ABC4RD sells education and operating infrastructure:
+
+- course cohorts;
+- learning review;
+- completion certificate review;
+- practical lab and demo setup;
+- research bulletin sponsorship;
+- translation and native review support;
+- institutional academy setup.
+
+### 2.2 What ABC4RD Does Not Sell
+
+ABC4RD does not sell:
+
+- investments;
+- Academy tokens;
+- token appreciation;
+- trading signals;
+- custody;
+- accredited degrees without approval;
+- guaranteed employment;
+- legal, tax, medical, investment, or financial advice.
+
+### 2.3 Commercial Safety Rule
+
+Revenue must come from learning delivery, review work, infrastructure setup,
+scholarships, grants, and sponsorships. It must not depend on speculative
+assets, false partner claims, or guaranteed outcomes.
+
+## 3. Product Architecture
+
+### 3.1 Free Layer
+
+Purpose:
+
+- public credibility;
+- learner onboarding;
+- contributor onboarding;
+- source-backed education.
+
+Includes:
+
+- README and Start Here;
+- Course 01 public summary;
+- demo docs;
+- public research bulletins;
+- open issue paths.
+
+### 3.2 Individual Paid Layer
+
+Main offer:
+
+`Blockchain Foundations Cohort`
+
+Subsections:
+
+- cohort length;
+- learning outcomes;
+- weekly review;
+- demo assignment;
+- learner artifact;
+- optional certificate review.
+
+Price anchor:
+
+- `USD 49-149` for individual cohort;
+- `USD 199-399` for supported cohort.
+
+### 3.3 Certificate Review Layer
+
+Main offer:
+
+`Certificate Review Batch`
+
+Subsections:
+
+- evidence checklist;
+- monthly review window;
+- reviewer notes;
+- completion record;
+- rejection and resubmission rule.
+
+Price anchor:
+
+- `USD 25-75` per review;
+- `USD 250-1,500` for institution batch.
+
+Important rule:
+
+The fee pays for review labor. It does not buy approval.
+
+### 3.4 Team And Institutional Layer
+
+Main offer:
+
+`Institutional Academy Starter Pack`
+
+Subsections:
+
+- one course setup;
+- one language entry package;
+- demo setup;
+- review workflow;
+- bulletin template;
+- operating dashboard;
+- reporting rhythm.
+
+Price anchor:
+
+- `USD 1,500-3,000` starter;
+- `USD 5,000-12,000` regional;
+- `USD 15,000-50,000` institutional.
+
+### 3.5 Sponsorship And Grant Layer
+
+Purpose:
+
+- fund scholarship seats;
+- support public research bulletins;
+- support open-source education infrastructure.
+
+Boundaries:
+
+- no editorial control;
+- no certificate approval influence;
+- no false endorsement claim;
+- public naming only after review.
+
+## 4. Buyer Architecture
+
+### 4.1 Buyer Segments
+
+| Segment | Need | First offer |
+| --- | --- | --- |
+| Individual learners | practical blockchain and AI literacy | cohort |
+| Students | structured learning and portfolio artifact | cohort, scholarship seat |
+| Universities | curriculum and lab infrastructure | institutional starter |
+| Companies | staff literacy and innovation training | team cohort |
+| NGOs/foundations | measurable education outcomes | sponsored cohort |
+| Regional communities | local-language access | native review |
+| Ecosystem sponsors | credible public education support | sponsorship |
+
+### 4.2 Buyer Prioritization
+
+Start in this order:
+
+1. Individual learners.
+2. Student groups.
+3. Universities and training centers.
+4. Companies.
+5. NGOs, foundations, and sponsors.
+6. Regional education partners.
+
+## 5. Language And Territory Model
+
+### 5.1 Canonical Language
+
+English is the canonical source for commercial and policy materials.
+
+### 5.2 Language Groups
+
+The first language groups are:
+
+- English;
+- Russian;
+- Spanish;
+- Arabic;
+- French;
+- Chinese.
+
+Each language group needs:
+
+- canonical English source link;
+- draft translation status;
+- native review status;
+- preserved disclaimers;
+- pricing notes only after payment/legal review.
+
+### 5.3 Territory Rule
+
+Language is a packaging layer. Territory is a legal and payment layer.
+
+Territory-specific selling requires review for:
+
+- payment availability;
+- tax treatment;
+- consumer protection;
+- sanctions screening;
+- crypto legality;
+- refund rules;
+- advertising rules.
+
+## 6. Pricing Model
+
+### 6.1 Internal Reference Currency
+
+Use USD as the internal reference until accounting chooses another base
+currency.
+
+### 6.2 Public Price Ladder
+
+| Level | Offer | Price |
+| --- | --- | --- |
+| 0 | Public self-study | free |
+| 1 | Individual cohort | USD 49-149 |
+| 2 | Supported cohort | USD 199-399 |
+| 3 | Certificate review | USD 25-75 |
+| 4 | Institution batch review | USD 250-1,500 |
+| 5 | Team cohort | USD 1,000-5,000 |
+| 6 | Institutional starter | USD 1,500-50,000 |
+| 7 | Sponsorship / scholarship pack | custom |
+
+### 6.3 Discount And Scholarship Rules
+
+Allowed:
+
+- scholarship seats;
+- student discounts;
+- sponsor-funded cohorts;
+- institution-funded seats.
+
+Not allowed:
+
+- discounting certificate approval;
+- sponsor influence over review outcome;
+- hidden territory pricing without review.
+
+## 7. Revenue Streams
+
+### 7.1 Core Revenue
+
+- course cohorts;
+- supported cohorts;
+- certificate review fees;
+- team cohorts;
+- institutional starter packs.
+
+### 7.2 Support Revenue
+
+- sponsorship;
+- grants;
+- translation/native review;
+- lab/demo setup;
+- research bulletin support.
+
+### 7.3 Future Revenue
+
+Future revenue requires a separate approval decision:
+
+- AI Production Factory cohort;
+- Academy Operating System setup;
+- corporate innovation labs;
+- startup studio or venture pilots;
+- licensing or white-label education packages.
+
+## 8. Payment Architecture
+
+### 8.1 Fiat First
+
+Fiat is the default payment path.
+
+Payment rails:
+
+- bank transfer for institutions;
+- card payments for individuals;
+- invoice-based B2B payment;
+- sponsor invoice for scholarships.
+
+### 8.2 Crypto Pilot
+
+Crypto can exist only as a reviewed payment pilot.
+
+Allowed pilot scope:
+
+- education payments only;
+- no Academy token sale;
+- no custody;
+- no investment product;
+- no token-gated certificate;
+- no promise of appreciation.
+
+### 8.3 Other Value Types
+
+Other accepted value types:
+
+- grants;
+- sponsorship;
+- in-kind value;
+- service exchange;
+- equity/revenue share only in a separate legal structure.
+
+## 9. Money Flow
+
+### 9.1 Intake Flow
+
+1. Buyer chooses an approved offer.
+2. ABC4RD issues invoice, receipt, or sponsorship agreement.
+3. Payment or contribution is recorded.
+4. Refund and compliance status are recorded.
+5. Value is assigned to a treasury bucket.
+6. Delivery evidence is linked.
+7. Monthly review checks open obligations.
+
+### 9.2 Treasury Buckets
+
+| Bucket | Target |
+| --- | --- |
+| Operating reserve | 60-80% |
+| Teacher/contractor payments | 10-25% |
+| Scholarship fund | 5-15% |
+| Crypto treasury experiment | 0-10% |
+| Emergency reserve | 5-10% |
+
+### 9.3 Spending Rule
+
+No received value should be treated as spendable until payment record, refund
+status, delivery obligation, and compliance status are recorded.
+
+## 10. Cost Structure
+
+### 10.1 Direct Delivery Costs
+
+- instructors;
+- mentors;
+- reviewers;
+- demo maintenance;
+- translation/native review;
+- certificate record preparation.
+
+### 10.2 Operating Costs
+
+- payment processing;
+- accounting;
+- legal/tax review;
+- GitHub and infrastructure;
+- design and publishing;
+- community operations.
+
+### 10.3 Growth Costs
+
+- scholarships;
+- public events;
+- partner outreach;
+- contributor onboarding;
+- source review.
+
+## 11. Unit Economics
+
+### 11.1 Individual Cohort
+
+Track:
+
+- seats sold;
+- scholarship seats;
+- gross revenue;
+- mentor/reviewer hours;
+- platform/payment fees;
+- completion rate;
+- certificate review conversion.
+
+### 11.2 Certificate Review
+
+Track:
+
+- review fee;
+- reviewer minutes;
+- approval/revision/rejection rate;
+- resubmission rate;
+- dispute/refund rate.
+
+### 11.3 Institutional Starter
+
+Track:
+
+- contract value;
+- delivery weeks;
+- languages included;
+- workshops included;
+- reviewer hours;
+- support obligations;
+- renewal potential.
+
+## 12. Sales And Delivery Funnel
+
+### 12.1 Public Funnel
+
+```text
+Start Here
+  -> Course 01 summary
+  -> Demo
+  -> Cohort interest
+  -> Paid cohort
+  -> Evidence submission
+  -> Certificate review
+  -> Alumni / contributor path
+```
+
+### 12.2 Institutional Funnel
+
+```text
+Partner brief
+  -> discovery call
+  -> starter pack proposal
+  -> invoice / agreement
+  -> course setup
+  -> cohort delivery
+  -> report
+  -> renewal or regional expansion
+```
+
+## 13. Records And Ledgers
+
+### 13.1 Required Ledgers
+
+- invoice/receipt ledger;
+- cohort seat ledger;
+- certificate review ledger;
+- scholarship ledger;
+- sponsorship ledger;
+- crypto receipt log if pilot is approved;
+- in-kind contribution register.
+
+### 13.2 Required Fields
+
+Every financial record needs:
+
+- payer or contributor;
+- offer or value type;
+- currency or asset;
+- amount;
+- date;
+- status;
+- refund rule;
+- delivery obligation;
+- internal owner.
+
+## 14. Governance
+
+### 14.1 Approval Roles
+
+| Role | Approval area |
+| --- | --- |
+| Maintainer | offer scope and repo publication |
+| Finance owner | invoices, ledgers, treasury buckets |
+| Legal/tax reviewer | payment, refund, jurisdiction, crypto review |
+| Course owner | learning outcomes and delivery evidence |
+| Review owner | certificate review integrity |
+| Language reviewer | native review and disclaimer preservation |
+
+### 14.2 Review Cadence
+
+- weekly: cohort and payment status;
+- monthly: certificate review batch and scholarship ledger;
+- quarterly: pricing, refund rules, language/territory status;
+- yearly: financial model and compliance review.
+
+## 15. Metrics
+
+### 15.1 Revenue Metrics
+
+- gross revenue;
+- net revenue after payment fees;
+- revenue by offer;
+- revenue by language group;
+- scholarship-funded seats;
+- sponsorship/grant contribution.
+
+### 15.2 Delivery Metrics
+
+- course starts;
+- course completions;
+- review submissions;
+- certificates approved;
+- revision requests;
+- support hours per learner.
+
+### 15.3 Risk Metrics
+
+- refunds;
+- payment disputes;
+- failed payments;
+- unresolved compliance reviews;
+- crypto pilot exceptions;
+- public claim corrections.
+
+## 16. Launch Sequence
+
+### 16.1 Before Paid Public Launch
+
+Complete:
+
+- first offer approval;
+- fiat payment rail;
+- invoice/receipt template;
+- refund baseline;
+- scholarship ledger;
+- pricing page review;
+- crypto status decision.
+
+### 16.2 First 30 Days
+
+Run:
+
+- one free public self-study path;
+- one paid cohort pilot;
+- one certificate review batch;
+- one institutional starter conversation;
+- one scholarship allocation.
+
+### 16.3 First 90 Days
+
+Decide:
+
+- keep or revise pricing;
+- expand one language group;
+- add or reject crypto pilot;
+- publish first revenue/scholarship transparency summary;
+- prepare second course only after delivery proof.
+
+## 17. Source Documents
+
+- [ABC4RD Academy Financial Model v1](../financial-model-v1.md)
+- [Financial Decision Log v1](decision-log-v1.md)
+- [Offer Catalog v1](offer-catalog-v1.md)
+- [Payment And Treasury Policy v1](payment-and-treasury-policy-v1.md)
+- [Money Flow v1](money-flow-v1.md)
+- [Pricing Page Draft](pricing-page-draft.md)
+- [Compliance Reference Notes v1](compliance-reference-notes-v1.md)
+- [Financial Model Issue Drafts](financial-model-issue-drafts.md)
+- [Financial Model v1 Milestone](../milestones/financial-model-v1.md)
+
+## 18. GitHub Operating Issues
+
+Financial Model v1 is tracked in GitHub through:
+
+- approve the first three commercial offers;
+- select fiat payment rails;
+- decide crypto payment status;
+- create scholarship ledger;
+- review pricing by language group.
+
+These issues should remain open until the corresponding operating approval is
+real, not just documented.

--- a/docs/financial-model-v1.md
+++ b/docs/financial-model-v1.md
@@ -7,6 +7,9 @@ works, how language and territory packaging should be handled, and how money is
 accepted. It is an operating model, not legal, tax, investment, or financial
 advice.
 
+For the full section-by-section operating picture, start with
+[Financial Model Map v1](finance/financial-model-map-v1.md).
+
 ## Positioning
 
 ABC4RD Academy sells education, review, practical labs, research briefings, and

--- a/docs/milestones/financial-model-v1.md
+++ b/docs/milestones/financial-model-v1.md
@@ -17,6 +17,7 @@ uncontrolled offers, token promises, or territory-specific legal complexity.
 
 ## Source Documents
 
+- [Financial Model Map v1](../finance/financial-model-map-v1.md)
 - [ABC4RD Academy Financial Model v1](../financial-model-v1.md)
 - [Financial Decision Log v1](../finance/decision-log-v1.md)
 - [Offer Catalog v1](../finance/offer-catalog-v1.md)


### PR DESCRIPTION
## Summary

- Adds `docs/finance/financial-model-map-v1.md` as the section-by-section overview of the ABC4RD Academy financial model.
- Connects the map from README, the financial model baseline, and the Financial Model v1 milestone.
- Organizes the model into offers, buyers, languages/territories, pricing, revenue streams, payments, treasury, costs, unit economics, ledgers, governance, metrics, and launch sequence.

## Verification

- `git diff --check`
- `npx markdownlint-cli2 "**/*.md" "#demos/**/node_modules"`
- `codespell` over tracked and newly added files, excluding local node_modules and generated locks